### PR TITLE
Do not needlessly require the `sys` module in `lib.js`.

### DIFF
--- a/lib/sync.js
+++ b/lib/sync.js
@@ -1,6 +1,5 @@
 var
 	fs = require('fs'),
-	sys = require('sys'),
 	exec = require('child_process').exec,
 	async = require('async'),
 	xtend = require('xtend'),


### PR DESCRIPTION
`sys` module wasn't used in `lib.js`. Also, `sys` module is deprecated.

There is an ongoing discussion on removing the `sys` module completely in the next major version: nodejs/node#2405.

If you plan on using `sys` functionality, you should switch to the `util` module.
